### PR TITLE
fix(mgtool): use exec.command to solve unwanted logging from global

### DIFF
--- a/.mage/tools.mk
+++ b/.mage/tools.mk
@@ -1,7 +1,7 @@
 mage_folder := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 mage_generated_path := $(mage_folder)/gen
 mage_targets_file := $(mage_generated_path)/targets.mk
-mage := $(mage_generated_path)/local-mage 2> /dev/null
+mage := $(mage_generated_path)/local-mage
 
 include $(mage_targets_file)
 


### PR DESCRIPTION
After closer debugging, and talking with the mage developers. We get the unwanted logging because the global is set up before logging is configured.