### PR TITLE
fix(mgtool): format git root path string to get correct path

### DIFF
--- a/mgtool/configuration.go
+++ b/mgtool/configuration.go
@@ -40,7 +40,7 @@ func GetGitRootPath(path string) string {
 	if err := c.Run(); err != nil {
 		panic(err)
 	}
-	return filepath.Join(output.String(), path)
+	return filepath.Join(strings.TrimSpace(output.String()), path)
 }
 
 func GetPath() string {


### PR DESCRIPTION
The previous PR did not fail, because technically it did download dependencies to a folder, not the expected one though. Needed to do some string formatting, tested locally and tools now ends up in the correct dir