### PR TITLE
ci: migrate to go-semantic-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,7 @@ jobs:
         run: make
 
       - name: Release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: make semantic-release branch=main ci=true
+        uses: go-semantic-release/action@v1.15.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          allow-initial-development-versions: true

--- a/.mage/magefile.go
+++ b/.mage/magefile.go
@@ -22,9 +22,6 @@ import (
 	"go.einride.tech/mage-tools/targets/mggoreview"
 
 	// mage:import
-	_ "go.einride.tech/mage-tools/targets/mgsemanticrelease"
-
-	// mage:import
 	"go.einride.tech/mage-tools/targets/mgprettier"
 )
 


### PR DESCRIPTION
Part of removing build-time dependency on Node.js for Go projects.
