### PR TITLE
feat(golangcilint): disable `forcetypeassert` linter

### DIFF
--- a/targets/mggolangcilint/golangci.yml
+++ b/targets/mggolangcilint/golangci.yml
@@ -38,10 +38,6 @@ linters:
     # [fast: false, auto-fix: false]
     - exportloopref
 
-    # Find forced type assertions.
-    # [fast: true, auto-fix: false]
-    - forcetypeassert
-
     # Check package import order and make it always deterministic.
     # [fast: true, auto-fix: true]
     - gci


### PR DESCRIPTION
this linter has a bit too many false positives where the assetion has
been checked beforehand. Let's remove it for now and re-add it for a
stricter linter in the future.