### PR TITLE
fix: remove npm check

### DIFF
--- a/tools/mgclangformat/targets.go
+++ b/tools/mgclangformat/targets.go
@@ -39,11 +39,6 @@ func FormatProtoCommand(path string) *exec.Cmd {
 type Prepare mgtool.Prepare
 
 func (Prepare) ClangFormat() error {
-	// Check if npm is installed
-	if err := mgtool.Command("npm", "version").Run(); err != nil {
-		return err
-	}
-
 	var archiveName string
 	switch strings.Split(runtime.GOOS, "/")[0] {
 	case "linux":

--- a/tools/mgcommitlint/targets.go
+++ b/tools/mgcommitlint/targets.go
@@ -58,11 +58,6 @@ func LintCommand(ctx context.Context, branch string) *exec.Cmd {
 type Prepare mgtool.Prepare
 
 func (Prepare) Commitlint(ctx context.Context) error {
-	// Check if npm is installed
-	if err := mgtool.Command("npm", "version").Run(); err != nil {
-		return err
-	}
-
 	toolDir := filepath.Join(mgpath.Tools(), "commitlint")
 	binary := filepath.Join(toolDir, "node_modules", ".bin", "commitlint")
 	packageJSON := filepath.Join(toolDir, "package.json")

--- a/tools/mgprettier/targets.go
+++ b/tools/mgprettier/targets.go
@@ -61,11 +61,6 @@ func FormatYAML(ctx context.Context) *exec.Cmd {
 type Prepare mgtool.Prepare
 
 func (Prepare) Prettier(ctx context.Context) error {
-	// Check if npm is installed
-	if err := mgtool.Command("npm", "version").Run(); err != nil {
-		return err
-	}
-
 	toolDir := filepath.Join(mgpath.Tools(), "prettier")
 	binary := filepath.Join(toolDir, "node_modules", ".bin", "prettier")
 	packageJSON := filepath.Join(toolDir, "package.json")

--- a/tools/mgsemanticrelease/targets.go
+++ b/tools/mgsemanticrelease/targets.go
@@ -47,11 +47,6 @@ func ReleaseCommand(ctx context.Context, branch string, ci bool) *exec.Cmd {
 type Prepare mgtool.Prepare
 
 func (Prepare) SemanticRelease(ctx context.Context, branch string) error {
-	// Check if npm is installed
-	if err := mgtool.Command("npm", "version").Run(); err != nil {
-		return err
-	}
-
 	toolDir := filepath.Join(mgpath.Tools(), "semantic-release")
 	binary := filepath.Join(toolDir, "node_modules", ".bin", "semantic-release")
 	releasercJSON := filepath.Join(toolDir, ".releaserc.json")


### PR DESCRIPTION
I was changing this command not to print to standard out, but then I figured this error is kinda overrated. We dont do sanity checks like this on other tools. Just let the system handle it and error out on the install command.