### PR TITLE
feat(mgpath): panic if finding files fails

### DIFF
--- a/mgpath/path.go
+++ b/mgpath/path.go
@@ -49,7 +49,7 @@ func FromBins(pathElems ...string) string {
 	return FromGitRoot(append([]string{MageDir, ToolsDir, BinDir}, pathElems...)...)
 }
 
-func FindFilesWithExtension(path, ext string) ([]string, error) {
+func FindFilesWithExtension(path, ext string) []string {
 	var files []string
 	if err := filepath.WalkDir(path, func(path string, d fs.DirEntry, err error) error {
 		if filepath.Ext(path) == ext {
@@ -57,7 +57,7 @@ func FindFilesWithExtension(path, ext string) ([]string, error) {
 		}
 		return nil
 	}); err != nil {
-		return nil, err
+		panic(err)
 	}
-	return files, nil
+	return files
 }

--- a/tools/mgclangformat/tools.go
+++ b/tools/mgclangformat/tools.go
@@ -24,12 +24,9 @@ func Command(args ...string) *exec.Cmd {
 }
 
 func FormatProtoCommand(path string) *exec.Cmd {
-	protoFiles, err := mgpath.FindFilesWithExtension(path, ".proto")
-	if err != nil {
-		panic(err)
-	}
+	protoFiles := mgpath.FindFilesWithExtension(path, ".proto")
 	if len(protoFiles) == 0 {
-		panic(fmt.Errorf("found no files to format"))
+		panic("found no files to format")
 	}
 	args := []string{"-i", "--style={BasedOnStyle: Google, ColumnLimit: 0, Language: Proto}"}
 	args = append(args, protoFiles...)


### PR DESCRIPTION
Conventionally helper methods always panic and don't return errors.
