### PR TITLE
Reduce API surface and rely more on *exec.Cmd API

### DIFF
--- a/.mage/magefile.go
+++ b/.mage/magefile.go
@@ -50,12 +50,12 @@ func FormatYaml() error {
 
 func GoModTidy() error {
 	mglog.Logger("go-mod-tidy").Info("tidying Go module files...")
-	return mggo.GoModTidy().Run()
+	return mggo.Command("mod", "tidy", "-v").Run()
 }
 
 func GoTest() error {
 	mglog.Logger("go-test").Info("running Go unit tests..")
-	return mggo.GoTest().Run()
+	return mggo.TestCommand().Run()
 }
 
 func Goreview(ctx context.Context) error {

--- a/.mage/magefile.go
+++ b/.mage/magefile.go
@@ -11,7 +11,7 @@ import (
 	"go.einride.tech/mage-tools/mgmake"
 	"go.einride.tech/mage-tools/mgpath"
 	"go.einride.tech/mage-tools/tools/mgconvco"
-	"go.einride.tech/mage-tools/tools/mggitverifynodiff"
+	"go.einride.tech/mage-tools/tools/mggit"
 	"go.einride.tech/mage-tools/tools/mggo"
 	"go.einride.tech/mage-tools/tools/mggolangcilint"
 	"go.einride.tech/mage-tools/tools/mggoreview"
@@ -80,5 +80,5 @@ func ConvcoCheck(ctx context.Context) error {
 
 func GitVerifyNoDiff() error {
 	mglog.Logger("git-verify-no-diff").Info("verifying that git has no diff...")
-	return mggitverifynodiff.GitVerifyNoDiff()
+	return mggit.VerifyNoDiff()
 }

--- a/.mage/magefile.go
+++ b/.mage/magefile.go
@@ -65,7 +65,7 @@ func Goreview(ctx context.Context) error {
 
 func GolangciLint(ctx context.Context) error {
 	mglog.Logger("golangci-lint").Info("running...")
-	return mggolangcilint.LintCommand(ctx).Run()
+	return mggolangcilint.RunCommand(ctx).Run()
 }
 
 func FormatMarkdown(ctx context.Context) error {

--- a/cmd/build/main.go
+++ b/cmd/build/main.go
@@ -32,7 +32,7 @@ func main() {
 	if err := os.WriteFile(makeGenGo, mgmakeGen, 0o600); err != nil {
 		panic(err)
 	}
-	cmd = mggo.GoModTidy()
+	cmd = mggo.Command("mod", "tidy")
 	cmd.Dir = mageDir
 	if err := cmd.Run(); err != nil {
 		panic(err)

--- a/example/.mage/magefile.go
+++ b/example/.mage/magefile.go
@@ -11,7 +11,7 @@ import (
 	"go.einride.tech/mage-tools/mgmake"
 	"go.einride.tech/mage-tools/mgpath"
 	"go.einride.tech/mage-tools/tools/mgconvco"
-	"go.einride.tech/mage-tools/tools/mggitverifynodiff"
+	"go.einride.tech/mage-tools/tools/mggit"
 	"go.einride.tech/mage-tools/tools/mggo"
 	"go.einride.tech/mage-tools/tools/mggolangcilint"
 	"go.einride.tech/mage-tools/tools/mggoreview"
@@ -79,5 +79,5 @@ func ConvcoCheck(ctx context.Context) error {
 
 func GitVerifyNoDiff() error {
 	mglog.Logger("git-verify-no-diff").Info("verifying that git has no diff...")
-	return mggitverifynodiff.GitVerifyNoDiff()
+	return mggit.VerifyNoDiff()
 }

--- a/example/.mage/magefile.go
+++ b/example/.mage/magefile.go
@@ -64,7 +64,7 @@ func GoTest() error {
 
 func GolangciLint(ctx context.Context) error {
 	mglog.Logger("golangci-lint").Info("running...")
-	return mggolangcilint.LintCommand(ctx).Run()
+	return mggolangcilint.RunCommand(ctx).Run()
 }
 
 func FormatMarkdown(ctx context.Context) error {

--- a/example/.mage/magefile.go
+++ b/example/.mage/magefile.go
@@ -49,7 +49,7 @@ func FormatYaml() error {
 
 func GoModTidy() error {
 	mglog.Logger("go-mod-tidy").Info("tidying Go module files...")
-	return mggo.GoModTidy().Run()
+	return mggo.Command("mod", "tidy", "-v").Run()
 }
 
 func Goreview(ctx context.Context) error {
@@ -59,7 +59,7 @@ func Goreview(ctx context.Context) error {
 
 func GoTest() error {
 	mglog.Logger("go-test").Info("running Go unit tests..")
-	return mggo.GoTest().Run()
+	return mggo.TestCommand().Run()
 }
 
 func GolangciLint(ctx context.Context) error {

--- a/main.go
+++ b/main.go
@@ -76,7 +76,7 @@ func initMageTools() error {
 	if err := cmd.Run(); err != nil {
 		return err
 	}
-	cmd = mggo.GoModTidy()
+	cmd = mggo.Command("mod", "tidy")
 	cmd.Dir = mageDir
 	if err := cmd.Run(); err != nil {
 		return err

--- a/tools/mgclangformat/tools.go
+++ b/tools/mgclangformat/tools.go
@@ -23,14 +23,9 @@ func Command(args ...string) *exec.Cmd {
 	return mgtool.Command(commandPath, args...)
 }
 
-func FormatProtoCommand(path string) *exec.Cmd {
-	protoFiles := mgpath.FindFilesWithExtension(path, ".proto")
-	if len(protoFiles) == 0 {
-		panic("found no files to format")
-	}
-	args := []string{"-i", "--style={BasedOnStyle: Google, ColumnLimit: 0, Language: Proto}"}
-	args = append(args, protoFiles...)
-	return Command(args...)
+func FormatProtoCommand(args ...string) *exec.Cmd {
+	const protoStyle = "--style={BasedOnStyle: Google, ColumnLimit: 0, Language: Proto}"
+	return Command(append([]string{"-i", protoStyle}, args...)...)
 }
 
 type Prepare mgtool.Prepare

--- a/tools/mggit/tools.go
+++ b/tools/mggit/tools.go
@@ -1,4 +1,4 @@
-package mggitverifynodiff
+package mggit
 
 import (
 	"bytes"
@@ -7,7 +7,7 @@ import (
 	"go.einride.tech/mage-tools/mgtool"
 )
 
-func GitVerifyNoDiff() error {
+func VerifyNoDiff() error {
 	cmd := mgtool.Command("git", "status", "--porcelain")
 	var b bytes.Buffer
 	cmd.Stdout = &b

--- a/tools/mggo/tools.go
+++ b/tools/mggo/tools.go
@@ -9,12 +9,17 @@ import (
 	"go.einride.tech/mage-tools/mgtool"
 )
 
-func GoTest() *exec.Cmd {
+func Command(args ...string) *exec.Cmd {
+	return mgtool.Command("go", args...)
+}
+
+func TestCommand() *exec.Cmd {
 	coverFile := mgpath.FromTools("go", "coverage", "go-test.txt")
 	if err := os.MkdirAll(filepath.Dir(coverFile), 0o755); err != nil {
 		panic(err)
 	}
-	return mgtool.Command("go", "test",
+	return Command(
+		"test",
 		"-race",
 		"-coverprofile",
 		coverFile,
@@ -22,8 +27,4 @@ func GoTest() *exec.Cmd {
 		"atomic",
 		"./...",
 	)
-}
-
-func GoModTidy() *exec.Cmd {
-	return mgtool.Command("go", "mod", "tidy", "-v")
 }

--- a/tools/mggolangcilint/tools.go
+++ b/tools/mggolangcilint/tools.go
@@ -31,7 +31,7 @@ func Command(ctx context.Context, args ...string) *exec.Cmd {
 	return mgtool.Command(commandPath, args...)
 }
 
-func LintCommand(ctx context.Context) *exec.Cmd {
+func RunCommand(ctx context.Context) *exec.Cmd {
 	configPath := mgpath.FromWorkDir(".golangci.yml")
 	cmd := Command(ctx)
 	if _, err := os.Stat(configPath); errors.Is(err, os.ErrNotExist) {
@@ -40,7 +40,6 @@ func LintCommand(ctx context.Context) *exec.Cmd {
 			panic(err)
 		}
 	}
-
 	cmd.Args = append(cmd.Args, "run", "-c", configPath, "--fix")
 	return cmd
 }

--- a/tools/mggolangmigrate/tools.go
+++ b/tools/mggolangmigrate/tools.go
@@ -23,16 +23,8 @@ func Command(ctx context.Context, args ...string) *exec.Cmd {
 	return mgtool.Command(commandPath, args...)
 }
 
-func MigrateCommand(ctx context.Context, source, database string) *exec.Cmd {
-	return Command(ctx, "-source", source, "-database", database, "up")
-}
-
 func (Prepare) GolangMigrate(ctx context.Context) error {
-	binary, err := mgtool.GoInstall(
-		ctx,
-		"github.com/golang-migrate/migrate/v4/cmd/migrate",
-		version,
-	)
+	binary, err := mgtool.GoInstall(ctx, "github.com/golang-migrate/migrate/v4/cmd/migrate", version)
 	if err != nil {
 		return err
 	}

--- a/tools/mggooglecloudprotoscrubber/tools.go
+++ b/tools/mggooglecloudprotoscrubber/tools.go
@@ -28,10 +28,6 @@ func Command(ctx context.Context, args ...string) *exec.Cmd {
 	return mgtool.Command(commandPath, args...)
 }
 
-func ScrubCommand(ctx context.Context, fileDescriptorPath string) *exec.Cmd {
-	return Command(ctx, "-f", fileDescriptorPath)
-}
-
 func (Prepare) GoogleCloudProtoScrubber(ctx context.Context) error {
 	const binaryName = "google-cloud-proto-scrubber"
 	binDir := mgpath.FromTools(binaryName, version)

--- a/tools/mgmarkdownfmt/tools.go
+++ b/tools/mgmarkdownfmt/tools.go
@@ -16,14 +16,14 @@ const version = "75134924a9fd3335f76a9709314c5f5cef4d6ddc"
 var commandPath string
 
 func Command(ctx context.Context, args ...string) *exec.Cmd {
-	ctx = logr.NewContext(ctx, mglog.Logger("format-markdown"))
-	mg.CtxDeps(ctx, Prepare.FormatMarkdown)
+	ctx = logr.NewContext(ctx, mglog.Logger("markdownfmt"))
+	mg.CtxDeps(ctx, Prepare.MarkdownFmt)
 	return mgtool.Command(commandPath, args...)
 }
 
 type Prepare mgtool.Prepare
 
-func (Prepare) FormatMarkdown(ctx context.Context) error {
+func (Prepare) MarkdownFmt(ctx context.Context) error {
 	binary, err := mgtool.GoInstall(ctx, "github.com/shurcooL/markdownfmt", version)
 	if err != nil {
 		return err


### PR DESCRIPTION
- feat: rename mggitverifynodiff to mggit
- feat(mggo): reduce API surface
- feat(mggolangcilint): rename LintCommand to RunCommand
- feat(mgclangformat): make FormatProtoCommand accept ...args
- feat(mggolangmigrate): remove MigrateCommand shorthand
- feat(mggooglecloudprotoscrubber): remove ScrubCommand
- chore(mgmarkdownfmt): fix naming
