### PR TITLE
feat: use context.Context and logr.Logger consistently

### DIFF
--- a/.mage/go.mod
+++ b/.mage/go.mod
@@ -3,12 +3,12 @@ module go.einride.tech/mage-tools/.mage
 go 1.17
 
 require (
+	github.com/go-logr/logr v1.2.2
 	github.com/magefile/mage v1.12.1
 	go.einride.tech/mage-tools v0.0.0-00010101000000-000000000000
 )
 
 require (
-	github.com/go-logr/logr v1.2.2 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/iancoleman/strcase v0.2.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect

--- a/.mage/magefile.go
+++ b/.mage/magefile.go
@@ -6,6 +6,7 @@ package main
 import (
 	"context"
 
+	"github.com/go-logr/logr"
 	"github.com/magefile/mage/mg"
 	"go.einride.tech/mage-tools/mglog"
 	"go.einride.tech/mage-tools/mgmake"
@@ -36,7 +37,7 @@ func All() {
 		Goreview,
 		GoTest,
 		FormatMarkdown,
-		FormatYaml,
+		FormatYAML,
 	)
 	mg.SerialDeps(
 		GoModTidy,
@@ -44,42 +45,50 @@ func All() {
 	)
 }
 
-func FormatYaml() error {
-	mglog.Logger("format-yaml").Info("formatting yaml files...")
-	return mgyamlfmt.FormatYAML()
+func FormatYAML(ctx context.Context) error {
+	ctx = mglog.NewContext(ctx, "format-yaml")
+	logr.FromContextOrDiscard(ctx).Info("formatting YAML files...")
+	return mgyamlfmt.FormatYAML(ctx)
 }
 
-func GoModTidy() error {
-	mglog.Logger("go-mod-tidy").Info("tidying Go module files...")
-	return mgtool.Command("go", "mod", "tidy", "-v").Run()
+func GoModTidy(ctx context.Context) error {
+	ctx = mglog.NewContext(ctx, "go-mod-tidy")
+	logr.FromContextOrDiscard(ctx).Info("tidying Go module files...")
+	return mgtool.Command(ctx, "go", "mod", "tidy", "-v").Run()
 }
 
-func GoTest() error {
-	mglog.Logger("go-test").Info("running Go unit tests..")
-	return mggo.TestCommand().Run()
+func GoTest(ctx context.Context) error {
+	ctx = mglog.NewContext(ctx, "go-test")
+	logr.FromContextOrDiscard(ctx).Info("running Go unit tests..")
+	return mggo.TestCommand(ctx).Run()
 }
 
 func Goreview(ctx context.Context) error {
-	mglog.Logger("goreview").Info("running...")
+	ctx = mglog.NewContext(ctx, "goreview")
+	logr.FromContextOrDiscard(ctx).Info("running...")
 	return mggoreview.Command(ctx, "-c", "1", "./...").Run()
 }
 
 func GolangciLint(ctx context.Context) error {
-	mglog.Logger("golangci-lint").Info("running...")
+	ctx = mglog.NewContext(ctx, "golangci-lint")
+	logr.FromContextOrDiscard(ctx).Info("running...")
 	return mggolangcilint.RunCommand(ctx).Run()
 }
 
 func FormatMarkdown(ctx context.Context) error {
-	mglog.Logger("format-markdown").Info("formatting..")
+	ctx = mglog.NewContext(ctx, "format-markdown")
+	logr.FromContextOrDiscard(ctx).Info("formatting Markdown files...")
 	return mgmarkdownfmt.Command(ctx, "-w", ".").Run()
 }
 
 func ConvcoCheck(ctx context.Context) error {
-	mglog.Logger("convco-check").Info("checking...")
+	ctx = mglog.NewContext(ctx, "convco-check")
+	logr.FromContextOrDiscard(ctx).Info("checking git commits...")
 	return mgconvco.Command(ctx, "check", "origin/main..HEAD").Run()
 }
 
-func GitVerifyNoDiff() error {
-	mglog.Logger("git-verify-no-diff").Info("verifying that git has no diff...")
-	return mggit.VerifyNoDiff()
+func GitVerifyNoDiff(ctx context.Context) error {
+	ctx = mglog.NewContext(ctx, "git-verify-no-diff")
+	logr.FromContextOrDiscard(ctx).Info("verifying that git has no diff...")
+	return mggit.VerifyNoDiff(ctx)
 }

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ format-markdown: $(magefile)
 
 .PHONY: format-yaml
 format-yaml: $(magefile)
-	@$(magefile) formatYaml
+	@$(magefile) formatYAML
 
 .PHONY: git-verify-no-diff
 git-verify-no-diff: $(magefile)

--- a/example/.mage/magefile.go
+++ b/example/.mage/magefile.go
@@ -36,7 +36,7 @@ func All() {
 		Goreview,
 		GoTest,
 		FormatMarkdown,
-		FormatYaml,
+		FormatYAML,
 	)
 	mg.SerialDeps(
 		GoModTidy,
@@ -44,42 +44,50 @@ func All() {
 	)
 }
 
-func FormatYaml() error {
-	mglog.Logger("format-yaml").Info("formatting yaml files...")
-	return mgyamlfmt.FormatYAML()
+func FormatYAML(ctx context.Context) error {
+	ctx = mglog.NewContext(ctx, "format-yaml")
+	logr.FromContextOrDiscard(ctx).Info("formatting YAML files...")
+	return mgyamlfmt.FormatYAML(ctx)
 }
 
-func GoModTidy() error {
-	mglog.Logger("go-mod-tidy").Info("tidying Go module files...")
-	return mgtool.Command("go", "mod", "tidy", "-v").Run()
+func GoModTidy(ctx context.Context) error {
+	ctx = mglog.NewContext(ctx, "go-mod-tidy")
+	logr.FromContextOrDiscard(ctx).Info("tidying Go module files...")
+	return mgtool.Command(ctx, "go", "mod", "tidy", "-v").Run()
+}
+
+func GoTest(ctx context.Context) error {
+	ctx = mglog.NewContext(ctx, "go-test")
+	logr.FromContextOrDiscard(ctx).Info("running Go unit tests..")
+	return mggo.TestCommand(ctx).Run()
 }
 
 func Goreview(ctx context.Context) error {
-	mglog.Logger("goreview").Info("running...")
+	ctx = mglog.NewContext(ctx, "goreview")
+	logr.FromContextOrDiscard(ctx).Info("running...")
 	return mggoreview.Command(ctx, "-c", "1", "./...").Run()
 }
 
-func GoTest() error {
-	mglog.Logger("go-test").Info("running Go unit tests..")
-	return mggo.TestCommand().Run()
-}
-
 func GolangciLint(ctx context.Context) error {
-	mglog.Logger("golangci-lint").Info("running...")
+	ctx = mglog.NewContext(ctx, "golangci-lint")
+	logr.FromContextOrDiscard(ctx).Info("running...")
 	return mggolangcilint.RunCommand(ctx).Run()
 }
 
 func FormatMarkdown(ctx context.Context) error {
-	mglog.Logger("format-markdown").Info("formatting..")
+	ctx = mglog.NewContext(ctx, "format-markdown")
+	logr.FromContextOrDiscard(ctx).Info("formatting Markdown files...")
 	return mgmarkdownfmt.Command(ctx, "-w", ".").Run()
 }
 
 func ConvcoCheck(ctx context.Context) error {
-	mglog.Logger("convco-check").Info("checking...")
-	return mgconvco.Command(ctx, "check", "origin/master..HEAD").Run()
+	ctx = mglog.NewContext(ctx, "convco-check")
+	logr.FromContextOrDiscard(ctx).Info("checking git commits...")
+	return mgconvco.Command(ctx, "check", "origin/main..HEAD").Run()
 }
 
-func GitVerifyNoDiff() error {
-	mglog.Logger("git-verify-no-diff").Info("verifying that git has no diff...")
-	return mggit.VerifyNoDiff()
+func GitVerifyNoDiff(ctx context.Context) error {
+	ctx = mglog.NewContext(ctx, "git-verify-no-diff")
+	logr.FromContextOrDiscard(ctx).Info("verifying that git has no diff...")
+	return mggit.VerifyNoDiff(ctx)
 }

--- a/mglog/logger.go
+++ b/mglog/logger.go
@@ -1,11 +1,17 @@
 package mglog
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/go-logr/logr"
 	"github.com/go-logr/logr/funcr"
 )
+
+// NewContext returns a new context.Context with a named logger.
+func NewContext(ctx context.Context, name string) context.Context {
+	return logr.NewContext(ctx, Logger(name))
+}
 
 // Logger returns a standard logger.
 func Logger(name string) logr.Logger {

--- a/mgtool/build.go
+++ b/mgtool/build.go
@@ -24,7 +24,7 @@ func GoInstall(ctx context.Context, pkg, version string) (string, error) {
 	}
 	pkgVersion := fmt.Sprintf("%s@%s", pkg, version)
 	logr.FromContextOrDiscard(ctx).Info("building...", "pkg", pkgVersion)
-	cmd := Command("go", "install", pkgVersion)
+	cmd := Command(ctx, "go", "install", pkgVersion)
 	cmd.Env = append(cmd.Env, "GOBIN="+filepath.Dir(executable))
 	if err := cmd.Run(); err != nil {
 		return "", err
@@ -37,7 +37,7 @@ func GoInstall(ctx context.Context, pkg, version string) (string, error) {
 }
 
 func GoInstallWithModfile(ctx context.Context, pkg, file string) (string, error) {
-	cmd := Command("go", "list", "-f", "{{.Module.Version}}", pkg)
+	cmd := Command(ctx, "go", "list", "-f", "{{.Module.Version}}", pkg)
 	cmd.Dir = filepath.Dir(file)
 	var b bytes.Buffer
 	cmd.Stdout = &b
@@ -58,7 +58,7 @@ func GoInstallWithModfile(ctx context.Context, pkg, file string) (string, error)
 		return symlink, nil
 	}
 	logr.FromContextOrDiscard(ctx).Info("building", "pkg", pkg)
-	cmd = Command("go", "install", pkg)
+	cmd = Command(ctx, "go", "install", pkg)
 	cmd.Dir = filepath.Dir(file)
 	cmd.Env = append(cmd.Env, "GOBIN="+filepath.Dir(executable))
 	if err := cmd.Run(); err != nil {

--- a/mgtool/exec.go
+++ b/mgtool/exec.go
@@ -1,6 +1,7 @@
 package mgtool
 
 import (
+	"context"
 	"os"
 	"os/exec"
 
@@ -8,11 +9,12 @@ import (
 )
 
 // Command should be used when returning exec.Cmd from tools to set opinionated standard fields.
-func Command(path string, args ...string) *exec.Cmd {
+func Command(_ context.Context, path string, args ...string) *exec.Cmd {
 	cmd := exec.Command(path)
 	cmd.Args = append(cmd.Args, args...)
 	cmd.Dir = mgpath.FromGitRoot(".")
 	cmd.Env = os.Environ()
+	// TODO: Pipe stdout/stderr through the current context logger to get tagged output.
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout
 	return cmd

--- a/tools/mgapilinter/tools.go
+++ b/tools/mgapilinter/tools.go
@@ -7,9 +7,7 @@ import (
 	"path/filepath"
 	"runtime"
 
-	"github.com/go-logr/logr"
 	"github.com/magefile/mage/mg"
-	"go.einride.tech/mage-tools/mglog"
 	"go.einride.tech/mage-tools/mgpath"
 	"go.einride.tech/mage-tools/mgtool"
 )
@@ -20,9 +18,8 @@ const version = "1.29.3"
 var commandPath string
 
 func Command(ctx context.Context, args ...string) *exec.Cmd {
-	ctx = logr.NewContext(ctx, mglog.Logger("api-linter-lint"))
 	mg.CtxDeps(ctx, Prepare.APILinter)
-	return mgtool.Command(commandPath, args...)
+	return mgtool.Command(ctx, commandPath, args...)
 }
 
 type Prepare mgtool.Prepare

--- a/tools/mgbuf/tools.go
+++ b/tools/mgbuf/tools.go
@@ -7,9 +7,7 @@ import (
 	"path/filepath"
 	"runtime"
 
-	"github.com/go-logr/logr"
 	"github.com/magefile/mage/mg"
-	"go.einride.tech/mage-tools/mglog"
 	"go.einride.tech/mage-tools/mgpath"
 	"go.einride.tech/mage-tools/mgtool"
 )
@@ -20,9 +18,8 @@ const version = "1.0.0-rc10"
 var commandPath string
 
 func Command(ctx context.Context, args ...string) *exec.Cmd {
-	ctx = logr.NewContext(ctx, mglog.Logger("buf"))
 	mg.CtxDeps(ctx, Prepare.Buf)
-	return mgtool.Command(commandPath, args...)
+	return mgtool.Command(ctx, commandPath, args...)
 }
 
 type Prepare mgtool.Prepare
@@ -52,7 +49,6 @@ func (Prepare) Buf(ctx context.Context) error {
 	); err != nil {
 		return fmt.Errorf("unable to download %s: %w", binaryName, err)
 	}
-
 	commandPath = binary
 	return nil
 }

--- a/tools/mgclangformat/tools.go
+++ b/tools/mgclangformat/tools.go
@@ -1,6 +1,7 @@
 package mgclangformat
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -18,19 +19,19 @@ const version = "1.6.0"
 // nolint: gochecknoglobals
 var commandPath string
 
-func Command(args ...string) *exec.Cmd {
+func Command(ctx context.Context, args ...string) *exec.Cmd {
 	mg.Deps(Prepare.ClangFormat)
-	return mgtool.Command(commandPath, args...)
+	return mgtool.Command(ctx, commandPath, args...)
 }
 
-func FormatProtoCommand(args ...string) *exec.Cmd {
+func FormatProtoCommand(ctx context.Context, args ...string) *exec.Cmd {
 	const protoStyle = "--style={BasedOnStyle: Google, ColumnLimit: 0, Language: Proto}"
-	return Command(append([]string{"-i", protoStyle}, args...)...)
+	return Command(ctx, append([]string{"-i", protoStyle}, args...)...)
 }
 
 type Prepare mgtool.Prepare
 
-func (Prepare) ClangFormat() error {
+func (Prepare) ClangFormat(ctx context.Context) error {
 	var archiveName string
 	switch strings.Split(runtime.GOOS, "/")[0] {
 	case "linux":
@@ -47,6 +48,7 @@ func (Prepare) ClangFormat() error {
 		return err
 	}
 	if err := mgtool.Command(
+		ctx,
 		"npm",
 		"--silent",
 		"install",

--- a/tools/mgcocogitto/tools.go
+++ b/tools/mgcocogitto/tools.go
@@ -9,9 +9,7 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/go-logr/logr"
 	"github.com/magefile/mage/mg"
-	"go.einride.tech/mage-tools/mglog"
 	"go.einride.tech/mage-tools/mgpath"
 	"go.einride.tech/mage-tools/mgtool"
 )
@@ -22,9 +20,8 @@ const version = "4.0.1"
 var commandPath string
 
 func Command(ctx context.Context, args ...string) *exec.Cmd {
-	ctx = logr.NewContext(ctx, mglog.Logger("cog"))
 	mg.CtxDeps(ctx, Prepare.Cog)
-	return mgtool.Command(commandPath, args...)
+	return mgtool.Command(ctx, commandPath, args...)
 }
 
 type Prepare mgtool.Prepare

--- a/tools/mgconvco/tools.go
+++ b/tools/mgconvco/tools.go
@@ -9,9 +9,7 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/go-logr/logr"
 	"github.com/magefile/mage/mg"
-	"go.einride.tech/mage-tools/mglog"
 	"go.einride.tech/mage-tools/mgpath"
 	"go.einride.tech/mage-tools/mgtool"
 )
@@ -22,9 +20,8 @@ const version = "0.3.7"
 var commandPath string
 
 func Command(ctx context.Context, args ...string) *exec.Cmd {
-	ctx = logr.NewContext(ctx, mglog.Logger("convco"))
 	mg.CtxDeps(ctx, Prepare.Convco)
-	return mgtool.Command(commandPath, args...)
+	return mgtool.Command(ctx, commandPath, args...)
 }
 
 type Prepare mgtool.Prepare

--- a/tools/mggit/tools.go
+++ b/tools/mggit/tools.go
@@ -2,21 +2,22 @@ package mggit
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"strings"
 
 	"go.einride.tech/mage-tools/mgtool"
 )
 
-func VerifyNoDiff() error {
-	cmd := mgtool.Command("git", "status", "--porcelain")
+func VerifyNoDiff(ctx context.Context) error {
+	cmd := mgtool.Command(ctx, "git", "status", "--porcelain")
 	var b bytes.Buffer
 	cmd.Stdout = &b
 	if err := cmd.Run(); err != nil {
 		return err
 	}
 	if b.String() != "" {
-		if err := mgtool.Command("git", "diff", "--patch").Run(); err != nil {
+		if err := mgtool.Command(ctx, "git", "diff", "--patch").Run(); err != nil {
 			return err
 		}
 		return fmt.Errorf("staging area is dirty, please add all files created by the build to .gitignore")
@@ -24,15 +25,15 @@ func VerifyNoDiff() error {
 	return nil
 }
 
-func Version() string {
-	cmd := mgtool.Command("git", "rev-parse", "--verify", "HEAD")
+func Version(ctx context.Context) string {
+	cmd := mgtool.Command(ctx, "git", "rev-parse", "--verify", "HEAD")
 	var b bytes.Buffer
 	cmd.Stdout = &b
 	if err := cmd.Run(); err != nil {
 		panic(err)
 	}
 	revision := strings.TrimSpace(b.String())
-	cmd = mgtool.Command("git", "status", "--porcelain")
+	cmd = mgtool.Command(ctx, "git", "status", "--porcelain")
 	var diff bytes.Buffer
 	cmd.Stdout = &diff
 	if err := cmd.Run(); err != nil {

--- a/tools/mggo/tools.go
+++ b/tools/mggo/tools.go
@@ -1,6 +1,7 @@
 package mggo
 
 import (
+	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -9,12 +10,13 @@ import (
 	"go.einride.tech/mage-tools/mgtool"
 )
 
-func TestCommand() *exec.Cmd {
+func TestCommand(ctx context.Context) *exec.Cmd {
 	coverFile := mgpath.FromTools("go", "coverage", "go-test.txt")
 	if err := os.MkdirAll(filepath.Dir(coverFile), 0o755); err != nil {
 		panic(err)
 	}
 	return mgtool.Command(
+		ctx,
 		"go",
 		"test",
 		"-shuffle",

--- a/tools/mggolangcilint/tools.go
+++ b/tools/mggolangcilint/tools.go
@@ -10,9 +10,7 @@ import (
 	"path/filepath"
 	"runtime"
 
-	"github.com/go-logr/logr"
 	"github.com/magefile/mage/mg"
-	"go.einride.tech/mage-tools/mglog"
 	"go.einride.tech/mage-tools/mgpath"
 	"go.einride.tech/mage-tools/mgtool"
 )
@@ -26,9 +24,8 @@ var commandPath string
 var defaultConfig string
 
 func Command(ctx context.Context, args ...string) *exec.Cmd {
-	ctx = logr.NewContext(ctx, mglog.Logger("golangci-lint"))
 	mg.CtxDeps(ctx, Prepare.GolangciLint)
-	return mgtool.Command(commandPath, args...)
+	return mgtool.Command(ctx, commandPath, args...)
 }
 
 func RunCommand(ctx context.Context) *exec.Cmd {

--- a/tools/mggolangmigrate/tools.go
+++ b/tools/mggolangmigrate/tools.go
@@ -4,9 +4,7 @@ import (
 	"context"
 	"os/exec"
 
-	"github.com/go-logr/logr"
 	"github.com/magefile/mage/mg"
-	"go.einride.tech/mage-tools/mglog"
 	"go.einride.tech/mage-tools/mgtool"
 )
 
@@ -18,9 +16,8 @@ var commandPath string
 type Prepare mgtool.Prepare
 
 func Command(ctx context.Context, args ...string) *exec.Cmd {
-	ctx = logr.NewContext(ctx, mglog.Logger("golang-migrate"))
 	mg.CtxDeps(ctx, Prepare.GolangMigrate)
-	return mgtool.Command(commandPath, args...)
+	return mgtool.Command(ctx, commandPath, args...)
 }
 
 func (Prepare) GolangMigrate(ctx context.Context) error {

--- a/tools/mggooglecloudprotoscrubber/tools.go
+++ b/tools/mggooglecloudprotoscrubber/tools.go
@@ -8,9 +8,7 @@ import (
 	"path/filepath"
 	"runtime"
 
-	"github.com/go-logr/logr"
 	"github.com/magefile/mage/mg"
-	"go.einride.tech/mage-tools/mglog"
 	"go.einride.tech/mage-tools/mgpath"
 	"go.einride.tech/mage-tools/mgtool"
 )
@@ -23,9 +21,8 @@ var commandPath string
 type Prepare mgtool.Prepare
 
 func Command(ctx context.Context, args ...string) *exec.Cmd {
-	ctx = logr.NewContext(ctx, mglog.Logger("google-cloud-proto-scrubber"))
 	mg.CtxDeps(ctx, Prepare.GoogleCloudProtoScrubber)
-	return mgtool.Command(commandPath, args...)
+	return mgtool.Command(ctx, commandPath, args...)
 }
 
 func (Prepare) GoogleCloudProtoScrubber(ctx context.Context) error {

--- a/tools/mggoreview/tools.go
+++ b/tools/mggoreview/tools.go
@@ -8,9 +8,7 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/go-logr/logr"
 	"github.com/magefile/mage/mg"
-	"go.einride.tech/mage-tools/mglog"
 	"go.einride.tech/mage-tools/mgpath"
 	"go.einride.tech/mage-tools/mgtool"
 )
@@ -23,9 +21,8 @@ var commandPath string
 type Prepare mgtool.Prepare
 
 func Command(ctx context.Context, args ...string) *exec.Cmd {
-	ctx = logr.NewContext(ctx, mglog.Logger("goreview"))
 	mg.CtxDeps(ctx, Prepare.Goreview)
-	return mgtool.Command(commandPath, args...)
+	return mgtool.Command(ctx, commandPath, args...)
 }
 
 func (Prepare) Goreview(ctx context.Context) error {

--- a/tools/mggosemanticrelease/tools.go
+++ b/tools/mggosemanticrelease/tools.go
@@ -9,9 +9,7 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/go-logr/logr"
 	"github.com/magefile/mage/mg"
-	"go.einride.tech/mage-tools/mglog"
 	"go.einride.tech/mage-tools/mgpath"
 	"go.einride.tech/mage-tools/mgtool"
 )
@@ -20,12 +18,11 @@ import (
 var commandPath string
 
 func Command(ctx context.Context, args ...string) *exec.Cmd {
-	ctx = logr.NewContext(ctx, mglog.Logger("go-semantic-release"))
 	mg.CtxDeps(ctx, Prepare.GoSemanticRelease)
-	return mgtool.Command(commandPath, args...)
+	return mgtool.Command(ctx, commandPath, args...)
 }
 
-func ReleaseFromCloudBuild(ctx context.Context, ci bool, repo string) *exec.Cmd {
+func ReleaseFromCloudBuildCommand(ctx context.Context, ci bool, repo string) *exec.Cmd {
 	args := []string{
 		"--allow-initial-development-versions",
 		"--allow-no-changes",
@@ -64,7 +61,6 @@ func (Prepare) GoSemanticRelease(ctx context.Context) error {
 		version,
 		hostOS,
 	)
-
 	if err := mgtool.FromRemote(
 		ctx,
 		binURL,

--- a/tools/mggrpcjava/tools.go
+++ b/tools/mggrpcjava/tools.go
@@ -9,9 +9,7 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/go-logr/logr"
 	"github.com/magefile/mage/mg"
-	"go.einride.tech/mage-tools/mglog"
 	"go.einride.tech/mage-tools/mgpath"
 	"go.einride.tech/mage-tools/mgtool"
 )
@@ -22,30 +20,25 @@ const version = "1.33.0"
 var commandPath string
 
 func Command(ctx context.Context) *exec.Cmd {
-	ctx = logr.NewContext(ctx, mglog.Logger("protoc-gen-grpc-java"))
 	mg.CtxDeps(ctx, Prepare.ProtocGenGrpcJava)
-	return mgtool.Command(commandPath)
+	return mgtool.Command(ctx, commandPath)
 }
 
 type Prepare mgtool.Prepare
 
 func (Prepare) ProtocGenGrpcJava(ctx context.Context) error {
 	const binaryName = "protoc-gen-grpc-java"
-
 	binDir := mgpath.FromTools("grpc-java", version, "bin")
 	binary := filepath.Join(binDir, binaryName)
-
 	// read the whole pom at once
 	b, err := os.ReadFile("pom.xml")
 	if err != nil {
 		panic(err)
 	}
 	s := string(b)
-
 	if !strings.Contains(s, fmt.Sprintf("<grpc.version>%s", version)) {
 		return fmt.Errorf("pom.xml is out of sync with gRPC Java version - expecting %s", version)
 	}
-
 	hostOS := runtime.GOOS
 	if hostOS == "darwin" {
 		hostOS = "osx"
@@ -54,7 +47,6 @@ func (Prepare) ProtocGenGrpcJava(ctx context.Context) error {
 	if hostArch == mgtool.AMD64 {
 		hostArch = mgtool.X8664
 	}
-
 	binURL := fmt.Sprintf(
 		"https://repo1.maven.org/maven2/io/grpc/%s/%s/%s-%s-%s-%s.exe",
 		binaryName,
@@ -64,7 +56,6 @@ func (Prepare) ProtocGenGrpcJava(ctx context.Context) error {
 		hostOS,
 		hostArch,
 	)
-
 	if err := mgtool.FromRemote(
 		ctx,
 		binURL,

--- a/tools/mghadolint/tools.go
+++ b/tools/mghadolint/tools.go
@@ -11,9 +11,7 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/go-logr/logr"
 	"github.com/magefile/mage/mg"
-	"go.einride.tech/mage-tools/mglog"
 	"go.einride.tech/mage-tools/mgpath"
 	"go.einride.tech/mage-tools/mgtool"
 )
@@ -25,13 +23,12 @@ const version = "2.8.0"
 var commandPath string
 
 func Command(ctx context.Context, args ...string) *exec.Cmd {
-	ctx = logr.NewContext(ctx, mglog.Logger("hadolint"))
 	mg.CtxDeps(ctx, Prepare.Hadolint)
-	return mgtool.Command(commandPath, args...)
+	return mgtool.Command(ctx, commandPath, args...)
 }
 
 func LintCommand(ctx context.Context) *exec.Cmd {
-	cmd := mgtool.Command("git", "ls-files", "--exclude-standard", "--cached", "--others", "--", "*Dockerfile*")
+	cmd := mgtool.Command(ctx, "git", "ls-files", "--exclude-standard", "--cached", "--others", "--", "*Dockerfile*")
 	var b bytes.Buffer
 	cmd.Stdout = &b
 	if err := cmd.Run(); err != nil {

--- a/tools/mgko/tools.go
+++ b/tools/mgko/tools.go
@@ -7,9 +7,7 @@ import (
 	"path/filepath"
 	"runtime"
 
-	"github.com/go-logr/logr"
 	"github.com/magefile/mage/mg"
-	"go.einride.tech/mage-tools/mglog"
 	"go.einride.tech/mage-tools/mgpath"
 	"go.einride.tech/mage-tools/mgtool"
 )
@@ -20,9 +18,8 @@ const version = "0.9.3"
 var commandPath string
 
 func Command(ctx context.Context, args ...string) *exec.Cmd {
-	ctx = logr.NewContext(ctx, mglog.Logger("ko"))
 	mg.CtxDeps(ctx, Prepare.Ko)
-	return mgtool.Command(commandPath, args...)
+	return mgtool.Command(ctx, commandPath, args...)
 }
 
 type Prepare mgtool.Prepare

--- a/tools/mgmarkdownfmt/tools.go
+++ b/tools/mgmarkdownfmt/tools.go
@@ -4,9 +4,7 @@ import (
 	"context"
 	"os/exec"
 
-	"github.com/go-logr/logr"
 	"github.com/magefile/mage/mg"
-	"go.einride.tech/mage-tools/mglog"
 	"go.einride.tech/mage-tools/mgtool"
 )
 
@@ -16,9 +14,8 @@ const version = "75134924a9fd3335f76a9709314c5f5cef4d6ddc"
 var commandPath string
 
 func Command(ctx context.Context, args ...string) *exec.Cmd {
-	ctx = logr.NewContext(ctx, mglog.Logger("markdownfmt"))
 	mg.CtxDeps(ctx, Prepare.MarkdownFmt)
-	return mgtool.Command(commandPath, args...)
+	return mgtool.Command(ctx, commandPath, args...)
 }
 
 type Prepare mgtool.Prepare

--- a/tools/mgprettier/tools.go
+++ b/tools/mgprettier/tools.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/magefile/mage/mg"
-	"go.einride.tech/mage-tools/mglog"
 	"go.einride.tech/mage-tools/mgpath"
 	"go.einride.tech/mage-tools/mgtool"
 )
@@ -31,9 +30,8 @@ var (
 )
 
 func Command(ctx context.Context, args ...string) *exec.Cmd {
-	ctx = logr.NewContext(ctx, mglog.Logger("prettier"))
 	mg.CtxDeps(ctx, Prepare.Prettier)
-	return mgtool.Command(commandPath, args...)
+	return mgtool.Command(ctx, commandPath, args...)
 }
 
 func FormatMarkdownCommand(ctx context.Context) *exec.Cmd {
@@ -64,7 +62,6 @@ func (Prepare) Prettier(ctx context.Context) error {
 	toolDir := mgpath.FromTools("prettier")
 	binary := filepath.Join(toolDir, "node_modules", ".bin", "prettier")
 	packageJSON := filepath.Join(toolDir, "package.json")
-
 	if err := os.MkdirAll(toolDir, 0o755); err != nil {
 		return err
 	}
@@ -81,6 +78,7 @@ func (Prepare) Prettier(ctx context.Context) error {
 	commandPath = symlink
 	logr.FromContextOrDiscard(ctx).Info("installing packages...")
 	return mgtool.Command(
+		ctx,
 		"npm",
 		"--silent",
 		"install",

--- a/tools/mgprotoc/tools.go
+++ b/tools/mgprotoc/tools.go
@@ -8,9 +8,7 @@ import (
 	"path/filepath"
 	"runtime"
 
-	"github.com/go-logr/logr"
 	"github.com/magefile/mage/mg"
-	"go.einride.tech/mage-tools/mglog"
 	"go.einride.tech/mage-tools/mgpath"
 	"go.einride.tech/mage-tools/mgtool"
 )
@@ -21,25 +19,21 @@ const version = "3.15.7"
 var commandPath string
 
 func Command(ctx context.Context, args ...string) *exec.Cmd {
-	ctx = logr.NewContext(ctx, mglog.Logger("protoc"))
 	mg.CtxDeps(ctx, Prepare.Protoc)
-	return mgtool.Command(commandPath, args...)
+	return mgtool.Command(ctx, commandPath, args...)
 }
 
 type Prepare mgtool.Prepare
 
 func (Prepare) Protoc(ctx context.Context) error {
 	const binaryName = "protoc"
-
 	binDir := mgpath.FromTools(binaryName, version)
 	binary := filepath.Join(binDir, "bin", binaryName)
-
 	hostOS := runtime.GOOS
 	hostArch := runtime.GOARCH
 	if hostArch == mgtool.AMD64 {
 		hostArch = mgtool.X8664
 	}
-
 	binURL := fmt.Sprintf(
 		"https://github.com/protocolbuffers/protobuf/releases/download/v%s/protoc-%s-%s-%s.zip",
 		version,
@@ -47,7 +41,6 @@ func (Prepare) Protoc(ctx context.Context) error {
 		hostOS,
 		hostArch,
 	)
-
 	if err := mgtool.FromRemote(
 		ctx,
 		binURL,
@@ -58,7 +51,6 @@ func (Prepare) Protoc(ctx context.Context) error {
 	); err != nil {
 		return fmt.Errorf("unable to download %s: %w", binaryName, err)
 	}
-
 	if err := os.RemoveAll(filepath.Join(binDir, "include")); err != nil {
 		return err
 	}

--- a/tools/mgsops/tools.go
+++ b/tools/mgsops/tools.go
@@ -7,9 +7,7 @@ import (
 	"path/filepath"
 	"runtime"
 
-	"github.com/go-logr/logr"
 	"github.com/magefile/mage/mg"
-	"go.einride.tech/mage-tools/mglog"
 	"go.einride.tech/mage-tools/mgpath"
 	"go.einride.tech/mage-tools/mgtool"
 )
@@ -20,9 +18,8 @@ const version = "3.7.1"
 var commandPath string
 
 func Command(ctx context.Context, args ...string) *exec.Cmd {
-	ctx = logr.NewContext(ctx, mglog.Logger("sops"))
 	mg.CtxDeps(ctx, Prepare.Sops)
-	return mgtool.Command(commandPath, args...)
+	return mgtool.Command(ctx, commandPath, args...)
 }
 
 type Prepare mgtool.Prepare
@@ -31,16 +28,13 @@ func (Prepare) Sops(ctx context.Context) error {
 	const binaryName = "sops"
 	binDir := mgpath.FromTools(binaryName, version)
 	binary := filepath.Join(binDir, binaryName)
-
 	hostOS := runtime.GOOS
-
 	binURL := fmt.Sprintf(
 		"https://github.com/mozilla/sops/releases/download/v%s/sops-v%s.%s",
 		version,
 		version,
 		hostOS,
 	)
-
 	if err := mgtool.FromRemote(
 		ctx,
 		binURL,

--- a/tools/mgyamlfmt/tools.go
+++ b/tools/mgyamlfmt/tools.go
@@ -2,6 +2,7 @@ package mgyamlfmt
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io/fs"
 	"io/ioutil"
@@ -12,7 +13,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-func FormatYAML() error {
+func FormatYAML(context.Context) error {
 	return filepath.WalkDir(mgpath.FromGitRoot("."), func(path string, d fs.DirEntry, err error) error {
 		if filepath.Ext(path) == ".yml" || filepath.Ext(path) == ".yaml" {
 			if err := formatFile(path); err != nil {


### PR DESCRIPTION
The logger name should always be the target name, and the logger should
propagate with the context through the whole call stack.
