### PR TITLE
feat(formatting): format Go code with gofumpt

### DIFF
--- a/.mage/magefile.go
+++ b/.mage/magefile.go
@@ -38,17 +38,12 @@ func All() {
 		GoTest,
 		FormatMarkdown,
 		FormatYAML,
+		FormatGo,
 	)
 	mg.SerialDeps(
 		GoModTidy,
 		GitVerifyNoDiff,
 	)
-}
-
-func FormatYAML(ctx context.Context) error {
-	ctx = logr.NewContext(ctx, mglogr.New("format-yaml"))
-	logr.FromContextOrDiscard(ctx).Info("formatting YAML files...")
-	return mgyamlfmt.FormatYAML(ctx)
 }
 
 func GoModTidy(ctx context.Context) error {
@@ -79,6 +74,20 @@ func FormatMarkdown(ctx context.Context) error {
 	ctx = logr.NewContext(ctx, mglogr.New("format-markdown"))
 	logr.FromContextOrDiscard(ctx).Info("formatting Markdown files...")
 	return mgmarkdownfmt.Command(ctx, "-w", ".").Run()
+}
+
+func FormatYAML(ctx context.Context) error {
+	ctx = logr.NewContext(ctx, mglogr.New("format-yaml"))
+	logr.FromContextOrDiscard(ctx).Info("formatting YAML files...")
+	return mgyamlfmt.FormatYAML(ctx)
+}
+
+func FormatGo(ctx context.Context) error {
+	ctx = logr.NewContext(ctx, mglogr.New("format-go"))
+	logr.FromContextOrDiscard(ctx).Info("formatting Go files...")
+	return mggolangcilint.
+		Command(ctx, "run", "--disable-all", "--no-config", "--enable", "gofumpt", "--fix").
+		Run()
 }
 
 func ConvcoCheck(ctx context.Context) error {

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,10 @@ all: $(magefile)
 convco-check: $(magefile)
 	@$(magefile) convcoCheck
 
+.PHONY: format-go
+format-go: $(magefile)
+	@$(magefile) formatGo
+
 .PHONY: format-markdown
 format-markdown: $(magefile)
 	@$(magefile) formatMarkdown

--- a/example/.mage/magefile.go
+++ b/example/.mage/magefile.go
@@ -38,17 +38,12 @@ func All() {
 		GoTest,
 		FormatMarkdown,
 		FormatYAML,
+		FormatGo,
 	)
 	mg.SerialDeps(
 		GoModTidy,
 		GitVerifyNoDiff,
 	)
-}
-
-func FormatYAML(ctx context.Context) error {
-	ctx = logr.NewContext(ctx, mglogr.New("format-yaml"))
-	logr.FromContextOrDiscard(ctx).Info("formatting YAML files...")
-	return mgyamlfmt.FormatYAML(ctx)
 }
 
 func GoModTidy(ctx context.Context) error {
@@ -79,6 +74,20 @@ func FormatMarkdown(ctx context.Context) error {
 	ctx = logr.NewContext(ctx, mglogr.New("format-markdown"))
 	logr.FromContextOrDiscard(ctx).Info("formatting Markdown files...")
 	return mgmarkdownfmt.Command(ctx, "-w", ".").Run()
+}
+
+func FormatYAML(ctx context.Context) error {
+	ctx = logr.NewContext(ctx, mglogr.New("format-yaml"))
+	logr.FromContextOrDiscard(ctx).Info("formatting YAML files...")
+	return mgyamlfmt.FormatYAML(ctx)
+}
+
+func FormatGo(ctx context.Context) error {
+	ctx = logr.NewContext(ctx, mglogr.New("format-go"))
+	logr.FromContextOrDiscard(ctx).Info("formatting Go files...")
+	return mggolangcilint.
+		Command(ctx, "run", "--disable-all", "--no-config", "--enable", "gofumpt", "--fix").
+		Run()
 }
 
 func ConvcoCheck(ctx context.Context) error {

--- a/main.go
+++ b/main.go
@@ -162,8 +162,10 @@ func addToDependabot() error {
 	if updatesIdx == 0 {
 		return fmt.Errorf("could not find updates key in dependabot.yml")
 	}
-	dependabotNode.Content[0].Content[updatesIdx].Content =
-		append(dependabotNode.Content[0].Content[updatesIdx].Content, mageNode.Content[0])
+	dependabotNode.Content[0].Content[updatesIdx].Content = append(
+		dependabotNode.Content[0].Content[updatesIdx].Content,
+		mageNode.Content[0],
+	)
 
 	var b bytes.Buffer
 	encoder := yaml.NewEncoder(&b)


### PR DESCRIPTION
By default we will format all Go code recursively from the current dir.
This implicitly relies on `GitVerifyNoDiff` to stop the execution if files were improperly formatted.

URL: https://github.com/mvdan/gofumpt