### PR TITLE
feat(clangformat): use binary instead of npm

### DIFF
--- a/tools/mgclangformat/tools.go
+++ b/tools/mgclangformat/tools.go
@@ -3,7 +3,6 @@ package mgclangformat
 import (
 	"context"
 	"fmt"
-	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
@@ -14,14 +13,14 @@ import (
 	"go.einride.tech/mage-tools/mgtool"
 )
 
-const version = "1.6.0"
-
-// nolint: gochecknoglobals
-var commandPath string
+const (
+	toolName = "clang-format"
+	version  = "v1.6.0"
+)
 
 func Command(ctx context.Context, args ...string) *exec.Cmd {
 	mg.Deps(Prepare.ClangFormat)
-	return mgtool.Command(ctx, commandPath, args...)
+	return mgtool.Command(ctx, mgpath.FromBins(toolName), args...)
 }
 
 func FormatProtoCommand(ctx context.Context, args ...string) *exec.Cmd {
@@ -32,38 +31,31 @@ func FormatProtoCommand(ctx context.Context, args ...string) *exec.Cmd {
 type Prepare mgtool.Prepare
 
 func (Prepare) ClangFormat(ctx context.Context) error {
-	var archiveName string
+	var osArch string
 	switch strings.Split(runtime.GOOS, "/")[0] {
 	case "linux":
-		archiveName = "linux_x64"
+		osArch = "linux_x64"
 	case "darwin":
-		archiveName = "darwin_x64"
+		osArch = "darwin_x64"
 	default:
 		return fmt.Errorf("unsupported OS: %s", runtime.GOOS)
 	}
-	toolDir := mgpath.FromTools("clang-format")
-	binary := filepath.Join(toolDir, "node_modules", "clang-format", "bin", archiveName, "clang-format")
-
-	if err := os.MkdirAll(toolDir, 0o755); err != nil {
-		return err
-	}
-	if err := mgtool.Command(
+	toolDir := mgpath.FromTools(toolName, version)
+	binary := filepath.Join(toolDir, toolName)
+	binURL := fmt.Sprintf(
+		"https://github.com/angular/clang-format/blob/%s/bin/%s/clang-format?raw=true",
+		version,
+		osArch,
+	)
+	if err := mgtool.FromRemote(
 		ctx,
-		"npm",
-		"--silent",
-		"install",
-		"--prefix",
-		toolDir,
-		"--no-save",
-		"--no-audit",
-		"clang-format@"+version,
-	).Run(); err != nil {
-		return err
+		binURL,
+		mgtool.WithDestinationDir(toolDir),
+		mgtool.WithRenameFile("clang-format?raw=true", toolName),
+		mgtool.WithSkipIfFileExists(binary),
+		mgtool.WithSymlink(binary),
+	); err != nil {
+		return fmt.Errorf("unable to download %s: %w", toolName, err)
 	}
-	symlink, err := mgtool.CreateSymlink(binary)
-	if err != nil {
-		return err
-	}
-	commandPath = symlink
 	return nil
 }


### PR DESCRIPTION
much faster and removes the middle-man.