### PR TITLE
feat(mgbalenacli): add balena-cli tool

### DIFF
--- a/mgtool/exec.go
+++ b/mgtool/exec.go
@@ -2,14 +2,17 @@ package mgtool
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 
 	"go.einride.tech/mage-tools/mgpath"
 )
 
 // Command should be used when returning exec.Cmd from tools to set opinionated standard fields.
 func Command(_ context.Context, path string, args ...string) *exec.Cmd {
+	// TODO: use exec.CommandContext when we have determined there are no side-effects.
 	cmd := exec.Command(path)
 	cmd.Args = append(cmd.Args, args...)
 	cmd.Dir = mgpath.FromGitRoot(".")
@@ -18,4 +21,15 @@ func Command(_ context.Context, path string, args ...string) *exec.Cmd {
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout
 	return cmd
+}
+
+// Output runs the given command, and returns all output from stdout in a neatly, trimmed manner,
+// panicking if an error occurs.
+func Output(cmd *exec.Cmd) string {
+	cmd.Stdout = nil
+	output, err := cmd.Output()
+	if err != nil {
+		panic(fmt.Sprintf("%s failed: %v", cmd.Path, err))
+	}
+	return strings.TrimSpace(string(output))
 }

--- a/tools/mgbalenacli/tools.go
+++ b/tools/mgbalenacli/tools.go
@@ -1,0 +1,86 @@
+package mgbalenacli
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/magefile/mage/mg"
+	"go.einride.tech/mage-tools/mgpath"
+	"go.einride.tech/mage-tools/mgtool"
+)
+
+const (
+	toolName   = "balena-cli"
+	binaryName = "balena"
+	version    = "v13.1.11"
+)
+
+func Command(ctx context.Context, args ...string) *exec.Cmd {
+	mg.CtxDeps(ctx, Prepare.Balena)
+	return mgtool.Command(ctx, mgpath.FromBins(binaryName), args...)
+}
+
+func Whoami(ctx context.Context) (WhoamiInfo, error) {
+	cmd := Command(ctx, "whoami")
+	cmd.Stdout = nil
+	output, err := cmd.Output()
+	if err != nil {
+		return WhoamiInfo{}, fmt.Errorf("balena whoami failed: %w", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(output)), "\n")[1:]
+	if len(lines) != 3 {
+		return WhoamiInfo{}, fmt.Errorf("unexpected output from Balena: %q", output)
+	}
+
+	// Example output we need to trim.
+	// == ACCOUNT INFORMATION
+	// USERNAME: <username>
+	// EMAIL:    <email>
+	// URL:      balena-cloud.com
+	trim := func(in string) string {
+		// trim everything before first :
+		i := strings.IndexByte(in, ':') + 1
+		return strings.TrimSpace(in[i:])
+	}
+	w := WhoamiInfo{
+		Username: trim(lines[0]),
+		Email:    trim(lines[1]),
+		URL:      trim(lines[2]),
+	}
+	return w, nil
+}
+
+type Prepare mgtool.Prepare
+
+func (Prepare) Balena(ctx context.Context) error {
+	binDir := mgpath.FromTools(toolName, version)
+	binary := filepath.Join(binDir, toolName, binaryName)
+	hostOS := runtime.GOOS
+	balena := fmt.Sprintf("balena-cli-%s-%s-x64-standalone", version, hostOS) // only x64 supported.
+	binURL := fmt.Sprintf(
+		"https://github.com/balena-io/balena-cli/releases/download/%s/%s.zip",
+		version,
+		balena,
+	)
+	if err := mgtool.FromRemote(
+		ctx,
+		binURL,
+		mgtool.WithDestinationDir(binDir),
+		mgtool.WithUnzip(),
+		mgtool.WithSkipIfFileExists(binary),
+		mgtool.WithSymlink(binary),
+	); err != nil {
+		return fmt.Errorf("unable to download %s: %w", toolName, err)
+	}
+	return nil
+}
+
+type WhoamiInfo struct {
+	Username string
+	Email    string
+	URL      string
+}

--- a/tools/mggit/tools.go
+++ b/tools/mggit/tools.go
@@ -4,19 +4,18 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"strings"
 
 	"go.einride.tech/mage-tools/mgtool"
 )
 
 func VerifyNoDiff(ctx context.Context) error {
 	cmd := mgtool.Command(ctx, "git", "status", "--porcelain")
-	var b bytes.Buffer
-	cmd.Stdout = &b
+	var status bytes.Buffer
+	cmd.Stdout = &status
 	if err := cmd.Run(); err != nil {
 		return err
 	}
-	if b.String() != "" {
+	if status.String() != "" {
 		if err := mgtool.Command(ctx, "git", "diff", "--patch").Run(); err != nil {
 			return err
 		}
@@ -26,20 +25,13 @@ func VerifyNoDiff(ctx context.Context) error {
 }
 
 func Version(ctx context.Context) string {
-	cmd := mgtool.Command(ctx, "git", "rev-parse", "--verify", "HEAD")
-	var b bytes.Buffer
-	cmd.Stdout = &b
-	if err := cmd.Run(); err != nil {
-		panic(err)
-	}
-	revision := strings.TrimSpace(b.String())
-	cmd = mgtool.Command(ctx, "git", "status", "--porcelain")
-	var diff bytes.Buffer
-	cmd.Stdout = &diff
-	if err := cmd.Run(); err != nil {
-		panic(err)
-	}
-	if diff.String() != "" {
+	revision := mgtool.Output(
+		mgtool.Command(ctx, "git", "rev-parse", "--verify", "HEAD"),
+	)
+	diff := mgtool.Output(
+		mgtool.Command(ctx, "git", "status", "--porcelain"),
+	)
+	if diff != "" {
 		revision += "-dirty"
 	}
 	return revision


### PR DESCRIPTION
Allows you to execute arbitrary commands using the 'balena' tool.

Also added a `Output` and `MustOutput` to mgtool. These functions makes it very easy to run git commands and retrieve the output immediately. Easy to run e.g. "git describe --tags" or similar and store the output in a string.