### PR TITLE
feat: change generated magefile to use master instead of main

### DIFF
--- a/cmd/init/example/.mage/magefile.go
+++ b/cmd/init/example/.mage/magefile.go
@@ -81,7 +81,7 @@ func FormatMarkdown(ctx context.Context) error {
 func ConvcoCheck(ctx context.Context) error {
 	ctx = logr.NewContext(ctx, mglogr.New("convco-check"))
 	logr.FromContextOrDiscard(ctx).Info("checking git commits...")
-	return mgconvco.Command(ctx, "check", "origin/main..HEAD").Run()
+	return mgconvco.Command(ctx, "check", "origin/master..HEAD").Run()
 }
 
 func GitVerifyNoDiff(ctx context.Context) error {


### PR DESCRIPTION
Github (and I think the industry at large?) is still using master as the default branch name for new repos so it makes more sense to generate 
magefile for master rather than main until this has been changed.
