### PR TITLE
feat: use module-aware mode when building Go from local mod file

### DIFF
--- a/mgtool/build.go
+++ b/mgtool/build.go
@@ -36,6 +36,8 @@ func GoInstall(ctx context.Context, pkg, version string) (string, error) {
 	return symlink, nil
 }
 
+// GoInstallWithModfile builds and installs a go binary given the package and a path
+// to the local go.mod file.
 func GoInstallWithModfile(ctx context.Context, pkg, file string) (string, error) {
 	cmd := Command(ctx, "go", "list", "-f", "{{.Module.Version}}", pkg)
 	cmd.Dir = filepath.Dir(file)
@@ -58,7 +60,7 @@ func GoInstallWithModfile(ctx context.Context, pkg, file string) (string, error)
 		return symlink, nil
 	}
 	logr.FromContextOrDiscard(ctx).Info("building", "pkg", pkg)
-	cmd = Command(ctx, "go", "install", pkg)
+	cmd = Command(ctx, "go", "install", pkg+"@"+version)
 	cmd.Dir = filepath.Dir(file)
 	cmd.Env = append(cmd.Env, "GOBIN="+filepath.Dir(executable))
 	if err := cmd.Run(); err != nil {


### PR DESCRIPTION
Often the purpose for wanting to build a Go binary from a remote package using the local go.mod file is so that we build the binary based on the same version as the local repo depends on however we don't want the local go.mod to include dependencies only needed to build that binary (which may be different than the "library" part of the remote repo) so we use the version specified in the local go.mod file but build the binary in module-aware mode so it brings its own dependencies
