### PR TITLE
fix: use os.Lstat instead of os.Stat for symlinks

### DIFF
--- a/mgtool/file.go
+++ b/mgtool/file.go
@@ -358,7 +358,7 @@ func CreateSymlink(src string) (string, error) {
 	if err := os.MkdirAll(mgpath.FromBinDir(), 0o755); err != nil {
 		return "", err
 	}
-	if _, err := os.Stat(symlink); err == nil {
+	if _, err := os.Lstat(symlink); err == nil {
 		if err := os.Remove(symlink); err != nil {
 			return "", err
 		}


### PR DESCRIPTION
`os.Stat` follows symlinks when the intention here is to check whether the symlink exists and remove it if it does. For that we need to use os.Lstat which does not follow symlinks
