### PR TITLE
fix: change main package name to magetools

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -1,2 +1,2 @@
 // Package magetools provides utilities and mage targets for building Go projects.
-package main
+package magetools


### PR DESCRIPTION
Go requires `main` packages to have a main method which we do not. This
causes go tooling to not work when running for example `go get
go.einride.tech/mage-tools` to upgrade to latest mage-tools version
